### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Requires Infrared4Arduino. Also uses LiquidCrystal_I2C version 1.1.2 o
 category=Device Control
 url=https://github.com/bengtmartensson/AGirs
 architectures=*
+depends=Infrared, Ethernet, LiquidCrystal_I2C, Beacon


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format