### PR TITLE
Make mkflasher.sh compatible with macOS

### DIFF
--- a/tools/mkflasher.sh
+++ b/tools/mkflasher.sh
@@ -36,7 +36,7 @@ fi
 cat > ${OUTFILE} <<EOF1
 #!/bin/sh
 
-# Flashing of the ${PACKAGE} ${BOARD}, using avrdude installed like Fedora.
+# Flashing of the ${PACKAGE} ${BOARD}, using avrdude.
 # Sometimes root access is required, depending on the system configuration.
 
 # Usage:
@@ -58,10 +58,17 @@ else
     PORT=/dev/ttyUSB0
 fi
 
+# Linux defaults
 AVRDUDE=/usr/bin/avrdude
 AVRDUDE_CONF=/etc/avrdude/avrdude.conf
 PART=atmega328p
 PROGRAMMER_ID=arduino
+
+# Mac defaults
+if [ $(uname -s) == Darwin ]; then
+  AVRDUDE=/Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/avrdude
+  AVRDUDE_CONF=/Applications/Arduino.app/Contents/Java/hardware/tools/avr/etc/avrdude.conf
+fi
 
 HEXFILE=/tmp/flasher\$\$
 


### PR DESCRIPTION
The original script is macOS compatible, just missing the correct location of avrdude.

This PR updates the script to point to the right location of avrdude on macOS, assuming Arduino IDE was installed in /Applications (the default location).

Tested manually on macOS Mojave with an Arduino UNO:

```
$ uname -a
Darwin macintosh.local 18.7.0 Darwin Kernel Version 18.7.0: Mon Feb 10 21:08:45 PST 2020; root:xnu-4903.278.28~1/RELEASE_X86_64 x86_64
$ ./GirsLite-1.0.2-nano-flasher.sh -n /dev/cu.usbmodem14101 

avrdude: Version 6.3-20190619
         Copyright (c) 2000-2005 Brian Dean, http://www.bdmicro.com/
         Copyright (c) 2007-2014 Joerg Wunsch
...
avrdude: 11962 bytes of flash verified

avrdude: safemode: lfuse reads as 0
avrdude: safemode: hfuse reads as 0
avrdude: safemode: efuse reads as 0
avrdude: safemode: Fuses OK (E:00, H:00, L:00)

avrdude done.  Thank you.

$
```