### PR TITLE
Add transmit invert support

### DIFF
--- a/examples/Girs/Girs.cpp
+++ b/examples/Girs/Girs.cpp
@@ -159,6 +159,12 @@ static constexpr size_t cmdLength = 20U;
 
 #ifdef TRANSMIT
 
+#ifdef TRANSMIT_INVERT
+#define INVERT true
+#else
+#define INVERT false
+#endif
+
 static bool sendIrSignal(const IrSignal &irSignal, unsigned int noSends=1) {
     if (noSends == 0)
         return false;
@@ -167,9 +173,9 @@ static bool sendIrSignal(const IrSignal &irSignal, unsigned int noSends=1) {
 #endif
     IrSender *irSender =
 #ifdef NON_MOD
-            (irSignal.getFrequency() == 0) ? (IrSender*) new IrSenderNonMod(NON_MOD_PIN) :
+            (irSignal.getFrequency() == 0) ? (IrSender*) new IrSenderNonMod(NON_MOD_PIN, INVERT) :
 #endif
-            (IrSender*) IrSenderPwm::getInstance(true);
+            (IrSender*) IrSenderPwm::getInstance(true, PWM_PIN, INVERT);
 
     irSender->sendIrSignal(irSignal, noSends);
 
@@ -348,9 +354,9 @@ void setup() {
     LedLcdManager::setupLedGroundPins();
     GirsUtils::setupReceivers();
     GirsUtils::setupSensors();
-#if defined(TRANSMIT)
+#if defined(TRANSMIT) && !defined(NON_MOD)
     // Make sure that sender is quiet (if reset or such)
-    IrSenderPwm::getInstance(true)->mute();
+    IrSenderPwm::getInstance(true, PWM_PIN, INVERT)->mute();
 #endif
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"

--- a/examples/Girs/GirsFat.config.h
+++ b/examples/Girs/GirsFat.config.h
@@ -90,6 +90,11 @@
 #define NON_MOD
 
 /**
+ * Define to invert the output of the transmit send pin.
+ */
+//#define TRANSMIT_INVERT
+
+/**
  * Define to support a reset command, Experimental!!
  */
 #define RESET

--- a/examples/Girs/GirsLite.config.h
+++ b/examples/Girs/GirsLite.config.h
@@ -89,6 +89,11 @@
 //#define NON_MOD
 
 /**
+ * Define to invert the output of the transmit send pin.
+ */
+//#define TRANSMIT_INVERT
+
+/**
  * Define to support a reset command, Experimental!!
  */
 //#define RESET


### PR DESCRIPTION
**Depends on https://github.com/bengtmartensson/Infrared4Arduino/pull/79**

This PR adds support for inverting the logic level of the IR send pin, for scenarios where HIGH = LED off and LOW = LED on. Fixes #61.

There are a few things I'm not happy with in this PR as-is, I'd appreciate some feedback:

- https://github.com/figgyc/AGirs/blob/58f4f2083421dd2485615f80e21b2c6d5ac6eef9/examples/Girs/Girs.cpp#L162 : I feel like there's a cleaner way to convert an ifdef to a boolean than this but I'm not sure.
- https://github.com/figgyc/AGirs/blob/58f4f2083421dd2485615f80e21b2c6d5ac6eef9/examples/Girs/Girs.cpp#L178 and L359: I've used the PWM_PIN define from the Infrared4Arduino library to fill in the default argument. That doesn't seem very clean to me, but as far as I can tell the library doesn't actually expose the PWM pin anywhere so I couldn't think of any other way, except for changing the order of the arguments which felt equally weird to me.